### PR TITLE
Fix javadoc issues on jdk11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,21 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>buildnumber-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <properties>


### PR DESCRIPTION
## Purpose
The release build is failing due to java version incompatibility with the maven-javadoc-plugin. This PR fixes it by adding custom configuration for the plugin. 

## Related Issue/s
- https://github.com/wso2/product-is/issues/21656